### PR TITLE
Fix context of call services

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,6 @@ You can also use without a template engine and by calling the startComponents an
         {name: 'test', id: 'test-2', { text: 'Bye' }}
     ]);
     
-    web.callService([{name: 'logger', func: 'log', args: ['Hello']}])
+    web.callService([{name: 'logger', func: 'log', args: 'Hello'}])
 </script>
 ```

--- a/src/core.js
+++ b/src/core.js
@@ -72,9 +72,7 @@ var web = (function web() {
             return;
         }
 
-        var serviceMethod = service[method];
-
-        return serviceMethod(args);
+        return service[method].call(service, args);
     };
 
     /**


### PR DESCRIPTION
Lost of `this` inside of a service when using for example ES6 classes for services.