### PR TITLE
Add service to load google map library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+ - FEATURE: Add service to load google map library. #12
  - FEATURE: Add skew scss mixin. #4
  - ENHANCEMENT: Add eslint and stylelint with circle ci. #11
  - FEATURE: Add expand js component. #6

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -44,4 +44,3 @@ var Api = (function() {
 })();
 
 module.exports = Api;
-

--- a/src/services/google-map-library.js
+++ b/src/services/google-map-library.js
@@ -1,0 +1,82 @@
+// Google Map Library service to load google map script.
+
+'use strict';
+
+var $ = require('jquery');
+
+var GoogleMapLibrary = (function() {
+    var googleMapLibrary = {
+        key: '',
+        promise: null
+    };
+
+    /**
+     * @method createPromise
+     * @private
+     * @returns {promise}
+     */
+    var createPromise = function() {
+        googleMapLibrary.promise = $.Deferred();
+    };
+
+    /**
+     * @method createInitFunction
+     * @private
+     */
+    var createInitFunction = function() {
+        window.initGoogleMaps = function() {
+            googleMapLibrary.promise.resolve();
+        };
+    };
+
+    /**
+     * @method getGoogleMapsScriptUrl
+     * @private
+     * @returns {String}
+     */
+    var getGoogleMapsScriptUrl = function() {
+        return 'https://maps.googleapis.com/maps/api/js?key=' + googleMapLibrary.getKey() + '&callback=initGoogleMaps';
+    };
+
+    /**
+     * @method addScript
+     * @private
+     */
+    var addScript = function() {
+        $('body').append('<script src="' + getGoogleMapsScriptUrl() + '" async defer></script>');
+    };
+
+    /**
+     * @method setKey
+     * @param {String} key
+     */
+    googleMapLibrary.setKey = function(key) {
+        googleMapLibrary.key = key;
+    };
+
+    /**
+     * @method getKey
+     * @returns {String}
+     */
+    googleMapLibrary.getKey = function() {
+        return googleMapLibrary.key;
+    };
+
+    /**
+     * @method load
+     * @returns {promise}
+     */
+    googleMapLibrary.load = function() {
+        if (!googleMapLibrary.promise) {
+            createPromise();
+            createInitFunction();
+            addScript();
+        }
+
+        return googleMapLibrary.promise;
+    };
+
+    return googleMapLibrary;
+})();
+
+module.exports = GoogleMapLibrary;


### PR DESCRIPTION
This adds a service to load google map library. So google map is only loaded when a component need it.

## Usage

```js
var googleMap = require('../services/google-map-library.js');

// ...

googleMap.load().done(function() {
    // google map is here loaded and you can use google.maps functions
});
```

To set the key from twig:

```js
var googleMap = require('../services/google-map-library.js');

web.registerService('google-map', googleMap);
```

```twig
<script>
    web.callServices([['google-map', 'setKey', '{{ GOOGLE_MAP_KEY }}']]);
    // ...
</script>
```

## TODO

 - [x] Update CHANGELOG.md