### PR TITLE
Add map math mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
- - BUGFIX: Fix expand component when element have multiple classes. #13
+ - FEATURE: Add map math mixin. #14
+ - BUGFIX: Fix expand component when element have multiple classes. #15
  - FEATURE: Add media scss mixin. #13
  - FEATURE: Add service to load google map library. #12
  - FEATURE: Add skew scss mixin. #4

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "eslint": "^4.19.1",
     "eslint-config-ma": "^1.0.1",
     "stylelint": "^9.2.1",
-    "stylelint-config-ma": "^1.1.0"
+    "stylelint-config-ma": "^1.1.1"
   }
 }

--- a/scss/tools/_map-math.scss
+++ b/scss/tools/_map-math.scss
@@ -15,11 +15,23 @@
 //     laptop: 120px,
 //     mobile: 60px
 // )
-@function mapMath($map, $multiplier) {
+@function mapMath($map, $param, $calculationType: '*') {
     $newMap: ();
 
     @each $key, $value in $map {
-        $newMap: map-merge($newMap, ($key: ($value * $multiplier)));
+        @if $calculationType == '*' {
+            $value: $value * $param;
+        } @elseif $calculationType == '/' {
+            $value: $value / $param;
+        } @elseif $calculationType == '+' {
+            $value: $value + $param;
+        } @elseif $calculationType == '-' {
+            $value: $value - $param;
+        } @else {
+            @error 'Following calculation type is not supported: #{$calculationType}';
+        }
+
+        $newMap: map-merge($newMap, ($key: $value));
     }
 
     @return $newMap;

--- a/scss/tools/_map-math.scss
+++ b/scss/tools/_map-math.scss
@@ -1,0 +1,83 @@
+// Map math mixins:
+
+// Map math will multiply the given list by the given multiplier.
+//
+// Usage:
+//
+// mapMath((
+//     laptop: 100px,
+//     mobile: 50px
+// ), 1.2);
+//
+// Output:
+//
+// (
+//     laptop: 120px,
+//     mobile: 60px
+// )
+@function mapMath($map, $multiplier) {
+    $newMap: ();
+
+    @each $key, $value in $map {
+        $newMap: map-merge($newMap, ($key: ($value * $multiplier)));
+    }
+
+    @return $newMap;
+}
+
+// Map math half will divide the given values by 2.
+//
+// Usage:
+//
+// mapMathHalf((
+//     laptop: 100px,
+//     mobile: 50px
+// ));
+//
+// Output:
+//
+// (
+//     laptop: 50px,
+//     mobile: 20px
+// )
+@function mapMathHalf($map) {
+    @return mapMath($map, 0.5);
+}
+
+// Map math negative will invert the given values.
+//
+// Usage:
+//
+// mapMathNegative((
+//     laptop: 100px,
+//     mobile: 50px
+// ));
+//
+// Output:
+//
+// (
+//     laptop: -100px,
+//     mobile: -50px
+// )
+@function mapMathNegative($map) {
+    @return mapMath($map, -1);
+}
+
+// Map math negative will invert the given values and divide by 2.
+//
+// Usage:
+//
+// mapMathNegative(
+//     laptop: 100px,
+//     mobile: 50px
+// );
+//
+// Output:
+//
+// (
+//     laptop: -50px,
+//     mobile: -25px
+// )
+@function mapMathHalfNegative($map) {
+    @return mapMath($map, -0.5);
+}


### PR DESCRIPTION
**Map math**

Usage:

```scss
mapMathHalf((
     desktop: 100px,
     mobile: 50px
), 1.2);
```

Output:

```scss
(
    desktop: 120px,
    mobile: 60px
)
```

**Map math half**

Usage:

```scss
mapMathHalf(
     desktop: 100px,
     mobile: 50px
);
```

Output:

```scss
(
    desktop: 50px,
    mobile: 20px
)
```

**Map math negative**

Map math negative will invert the given values.

Usage:

```scss
mapMathNegative(
    desktop: 100px,
    mobile: 50px
);
```

Output:

```scss
(
    desktop: -100px,
    mobile: -50px
)
```

**Example Usage with mediaEachMax**:

```scss
$gutter-widths: (
    default: 22px,
    desktop: 18px,
    tablet: 16px,
    smart: 6px,
);

.container {
    @include mediaEachMax(mapMathHalfNegative($gutter-widths), (
        margin-left,
        margin-right
    ));
}

.container__item {
     float: left;
     width: 25%;

    @include mediaEachMax(mapMathHalf($grid-gutter-widths), (
        padding-left,
        padding-right
    ));
}
```

Output:

```sass
.container {
  margin-left: -11px;
  margin-right: -11px;
}

@media only screen and (max-width: 1199px) {
  .container {
    margin-left: -9px;
    margin-right: -9px;
  }
}

@media only screen and (max-width: 991px) {
  .container {
    margin-left: -8px;
    margin-right: -8px;
  }
}

@media only screen and (max-width: 767px) {
  .container {
    margin-left: -3px;
    margin-right: -3px;
  }
}

.container__item {
  float: left;
  width: 25%;
  padding-left: 11px;
  padding-right: 11px;
}

@media only screen and (max-width: 1199px) {
  .container__item {
    padding-left: 9px;
    padding-right: 9px;
  }
}

@media only screen and (max-width: 991px) {
  .container__item {
    padding-left: 8px;
    padding-right: 8px;
  }
}

@media only screen and (max-width: 767px) {
  .container__item {
    padding-left: 3px;
    padding-right: 3px;
  }
}
```