### PR TITLE
Fix media max scss mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
- - BUGFIX: Fix media mixin to use the correct pixels. #16
+ - BUGFIX: Fix media mixin to use the correct pixels and allow multiple lists. #16
  - FEATURE: Add map math mixin. #14
  - BUGFIX: Fix expand component when element have multiple classes. #15
  - FEATURE: Add media scss mixin. #13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+ - BUGFIX: Fix media mixin to use the correct pixels. #16
  - FEATURE: Add map math mixin. #14
  - BUGFIX: Fix expand component when element have multiple classes. #15
  - FEATURE: Add media scss mixin. #13

--- a/scss/tools/_media.scss
+++ b/scss/tools/_media.scss
@@ -1,16 +1,23 @@
-// Media mixins
+// Media mixins:
+//
+// $breakpoints: (
+//     laptop: 1199px,     // 992px -> 1199px
+//     tablet: 991px,      // 768px ->  991px
+//     smart: 767px,       // 578px ->  767px
+//     mobile: 577px,      //   0px ->  577px
+// );
 $media-breakpoints: $breakpoints !default;
 
-// Media min automatically create a "only screen and (min-width: $param)" media query.
-@mixin mediaMin($pixels) {
-    @media only screen and (min-width: $pixels) {
+// Media min automatically create a "only screen and (min-width: $value)" media query.
+@mixin mediaMin($value) {
+    @media only screen and (min-width: $value) {
         @content;
     }
 }
 
-// Media max automatically create a "only screen and (max-width: $param)" media query.
-@mixin mediaMax($pixels) {
-    @media only screen and (max-width: $pixels) {
+// Media max automatically create a "only screen and (max-width: $value)" media query.
+@mixin mediaMax($value) {
+    @media only screen and (max-width: $value) {
         @content;
     }
 }
@@ -33,12 +40,27 @@ $media-breakpoints: $breakpoints !default;
 //     }
 // }
 @mixin media($condition) {
-    @if str-slice($condition, 1, 1) == '>' {
-        @include mediaMin(map-get($media-breakpoints, str-slice($condition, 2))) {
+    $function: str-slice($condition, 1, 1);
+    $currentBreakpoint: str-slice($condition, 2);
+
+    @if $function == '>' {
+        @include mediaMin(map-get($media-breakpoints, $currentBreakpoint) + 1px) {
             @content;
         }
-    } @else if str-slice($condition, 1, 1) == '<' {
-        @include mediaMax(map-get($media-breakpoints, str-slice($condition, 2))) {
+    } @else if $function == '<' {
+        $indexCondition: 1;
+
+        @if $currentBreakpoint != 'default' {
+            $indexCondition: index(map-keys($media-breakpoints), $currentBreakpoint) + 1;
+        }
+
+        @if $indexCondition > length($media-breakpoints) or $indexCondition < 1 {
+            @error 'Following condition is not allowed: #{$condition}';
+        }
+
+        $value: nth(nth($media-breakpoints, $indexCondition), 2);
+
+        @include mediaMax($value) {
             @content;
         }
     } @else {
@@ -52,8 +74,8 @@ $media-breakpoints: $breakpoints !default;
 //
 // .example {
 //     @include mediaEachMax((
-//         default: 0,
-//         desktop: 62px,
+//         default: auto,
+//         laptop: 62px,
 //         tablet: 64px,
 //         smart: 30px
 //     ), (
@@ -65,8 +87,8 @@ $media-breakpoints: $breakpoints !default;
 // Output:
 //
 // .example {
-//     margin-left: 0;
-//     margin-right: 0;
+//     margin-left: auto;
+//     margin-right: auto;
 // }
 //
 // @media only screen and (max-width: 1199px) {
@@ -98,14 +120,12 @@ $media-breakpoints: $breakpoints !default;
 
     @each $breakpoint-name, $breakpoint in $media-breakpoints {
         @if map-has-key($matrix, $breakpoint-name) {
-            @include media('<' + $breakpoint-name) {
+            @include mediaMax($breakpoint) {
                 @each $attribute in $attributes {
                     #{$attribute}: map-get($matrix, $breakpoint-name);
                 }
-
                 @content;
             }
         }
     }
 }
-

--- a/scss/tools/_media.scss
+++ b/scss/tools/_media.scss
@@ -4,7 +4,7 @@
 //     laptop: 1199px,     // 992px -> 1199px
 //     tablet: 991px,      // 768px ->  991px
 //     smart: 767px,       // 578px ->  767px
-//     mobile: 577px,      //   0px ->  577px
+//     mobile: 577px,      // 0px   ->  577px
 // );
 $media-breakpoints: $breakpoints !default;
 
@@ -72,15 +72,17 @@ $media-breakpoints: $breakpoints !default;
 //
 // Usage:
 //
+// $margins: (
+//     default: auto,
+//     laptop: 62px,
+//     tablet: 64px,
+//     smart: 30px
+// );
+//
 // .example {
 //     @include mediaEachMax((
-//         default: auto,
-//         laptop: 62px,
-//         tablet: 64px,
-//         smart: 30px
-//     ), (
-//         margin-left,
-//         margin-right
+//         margin-left: $margins,
+//         margin-right: $margins,
 //     ));
 // }
 //
@@ -111,20 +113,18 @@ $media-breakpoints: $breakpoints !default;
 //         margin-left: 30px;
 //     }
 // }
-@mixin mediaEachMax($matrix, $attributes) {
-    @if map-has-key($matrix, 'default') {
-        @each $attribute in $attributes {
-            #{$attribute}: map-get($matrix, 'default');
+@mixin mediaEachMax($attributes) {
+    @each $attribute-name, $matrix in $attributes {
+        @if map-has-key($matrix, 'default') {
+            #{$attribute-name}: map-get($matrix, 'default');
         }
-    }
 
-    @each $breakpoint-name, $breakpoint in $media-breakpoints {
-        @if map-has-key($matrix, $breakpoint-name) {
-            @include mediaMax($breakpoint) {
-                @each $attribute in $attributes {
-                    #{$attribute}: map-get($matrix, $breakpoint-name);
+        @each $breakpoint-name, $breakpoint in $media-breakpoints {
+            @if map-has-key($matrix, $breakpoint-name) {
+                @include mediaMax($breakpoint) {
+                    #{$attribute-name}: map-get($matrix, $breakpoint-name);
+                    @content;
                 }
-                @content;
             }
         }
     }

--- a/scss/tools/_media.scss
+++ b/scss/tools/_media.scss
@@ -118,10 +118,12 @@ $media-breakpoints: $breakpoints !default;
         @if map-has-key($matrix, 'default') {
             #{$attribute-name}: map-get($matrix, 'default');
         }
+    }
 
-        @each $breakpoint-name, $breakpoint in $media-breakpoints {
-            @if map-has-key($matrix, $breakpoint-name) {
-                @include mediaMax($breakpoint) {
+    @each $breakpoint-name, $breakpoint in $media-breakpoints {
+        @include mediaMax($breakpoint) {
+            @each $attribute-name, $matrix in $attributes {
+                @if map-has-key($matrix, $breakpoint-name) {
                     #{$attribute-name}: map-get($matrix, $breakpoint-name);
                     @content;
                 }
@@ -129,3 +131,4 @@ $media-breakpoints: $breakpoints !default;
         }
     }
 }
+


### PR DESCRIPTION
Currently maxWidth does use the false variable instead of you set `<tablet` it renders `<desktop` which is currently incorrect e.g.:

```scss
$breakpoints: (
    laptop: 1199px,     // 992px -> 1199px 
    tablet: 991px,      // 768px ->  991px
    smart: 767px,       // 578px ->  767px
    mobile: 577px,      //   0px ->  577px 
);

@include media('<laptop') {
    color: red;
}

@include media('>laptop') {
    color: red;
}
```

**Current output** (before this fix):

```css
@media only screen and (max-width: 1199px) { // this is not <laptop 
    color: red;
}

@media only screen and (min-width: 1199px) { // this is not >laptop 
    color: red;
}
```

**Expected output** (with this fix):

```css
@media only screen and (max-width: 991px) {
    color: red;
}

@media only screen and (max-width: 1200px) {
    color: red;
}
```

**Easier handling mediaEachMax**

Before:

New:

```scss
$widths: (
    default: 900px,
    laptop: 900px,
    tablet: 600px,
    smart: 500px
);

$margins: (
    default: 20px,
    laptop: 10px,
    tablet: 20px,
    smart: 10px
);

@include mediaMaxEach((
     max-width: $widths,
     margin-left: $margins,
     margin-right: $margins,
));
```