### PR TITLE
Add closeOnEsc to expand and toggle class instead of display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changes
 
-## unreleased
+## 1.3.1
 
  - BUGFIX: Define jquery as peer dependency. #23
+ - BUGFIX: Show correct stack trace for failed component start. #24
+ - ENHANCEMENT: Add closeOnEsc to expand and toggle class instead of display. #19
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module.exports = test;
 ```js
 // src/components/test-class.js
 
-class Test {
+export default class Test {
     constructor() {
         this.text = '';
     }
@@ -90,8 +90,6 @@ class Test {
         alert(this.text);
     }
 }
-
-module.exports Test;
 ```
 
 ### Create your first service

--- a/src/components/expand.js
+++ b/src/components/expand.js
@@ -11,24 +11,43 @@ module.exports = function Expand() {
         // Define necessary component elements, instance $el handed in on initialization
         expand.$el = $el;
         expand.id = $el.attr('id');
-        expand.toggleClass = expand.$el.attr('class').split(' ')[0] + '--open';
+        expand.closeOnEsc = options.closeOnEsc ? options.closeOnEsc : false;
         expand.$container = options.container ? $('#' + options.container) : $('#' + expand.id + '-container');
+        expand.modifier = options.modifier ? options.modifier : '--open';
+        expand.toggleButtonClass = expand.getFirstClass(expand.$el) + expand.modifier;
+        expand.toggleContainerClass = expand.getFirstClass(expand.$container) + expand.modifier;
 
         // Run init functions
         expand.bindEvents();
     };
 
+    expand.getFirstClass = function getFirstClass($element) {
+        return $element.attr('class').split(' ')[0];
+    };
+
     expand.bindEvents = function bindEvents() {
         expand.$el.on('click', expand.toggle);
+
+        if (expand.closeOnEsc) {
+            $(document).keyup(function(event) {
+                if (event.keyCode === 27) {
+                    expand.close();
+                }
+            });
+        }
     };
 
     expand.toggle = function toggle() {
-        expand.$el.toggleClass(expand.toggleClass);
-        expand.$container.toggle();
+        expand.$el.toggleClass(expand.toggleButtonClass);
+        expand.$container.toggleClass(expand.toggleContainerClass);
+    };
+
+    expand.close = function close() {
+        expand.$el.removeClass(expand.toggleButtonClass);
+        expand.$container.removeClass(expand.toggleContainerClass);
     };
 
     return {
         initialize: expand.initialize
     };
 };
-


### PR DESCRIPTION
1. Instead of toggling the display attribute it toggles a class which allows to use css animations or for example hide other containers over css selectors. fixes #18 

2. Also add a option to close the container on ESC so it can be used for overlays.

```twig
<button id="{{ register_component('expand', { id: 'menu', closeOnEsc: true }) }}" {# -#}
        class="menu__button icon-menu" {# -#}
        type="button">
</button>
```