### PR TITLE
Add unicode function for rendering content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+ - FEATURE: Add unicode function for rendering content variables. #20
+
+## 1.3.0
+
  - BUGFIX: Fix media mixin to use the correct pixels and allow multiple lists. #16
  - FEATURE: Add map math mixin. #14
  - BUGFIX: Fix expand component when element have multiple classes. #15

--- a/scss/tools/_unicode.scss
+++ b/scss/tools/_unicode.scss
@@ -1,0 +1,8 @@
+// Unicode:
+//
+// .test::before {
+//     content: unicode($icon-close);
+// }
+@function unicode($string) {
+    @return unquote('\"') + $string + unquote('\"');
+}


### PR DESCRIPTION
This function is used internal by icomoon to rendern icon.

If you want to change icon by a modifier you need this function:

```scss
&-open {
    content: unicode($icon-close);
}
```