### PR TITLE
Define jquery as peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+ - BUGFIX: Define jquery as peer dependency. #23
+
+## 1.3.0
+
  - BUGFIX: Fix media mixin to use the correct pixels and allow multiple lists. #16
  - FEATURE: Add map math mixin. #14
  - BUGFIX: Fix expand component when element have multiple classes. #15

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/massiveart/web-js/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=1.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The version of jquery should be defined in the project which used this library and not by library itself. This avoids having 2 or more different version of jquery in your project.

More about `peerDependencies` can be found here:

https://yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies
https://nodejs.org/en/blog/npm/peer-dependencies/