### PR TITLE
Show correct stack trace for failed component start

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -131,7 +131,7 @@ var web = (function web() {
             try {
                 web.startComponent(component.name, component.id, component.options);
             } catch (error) {
-                web.emitError('Component start failed for: ' + component.id + ' with ' + error);
+                web.emitError('Component "' + component.name + '" start failed for "' + component.id + '":', error);
             }
         });
     };
@@ -261,12 +261,11 @@ var web = (function web() {
     /**
      * Handle error messages
      * @method emitError
-     * @param {String} message
      */
-    web.emitError = function emitError(message) {
+    web.emitError = function emitError() {
         /* eslint-disable no-console */
         if (console && console.error) {
-            console.error(message);
+            console.error.apply(null, arguments);
         }
         /* eslint-enable no-console */
     };
@@ -287,4 +286,3 @@ var web = (function web() {
 })();
 
 module.exports = window.web = web;
-


### PR DESCRIPTION
Currently you don't get the correct stack trace when an error in the component start is thrown. By logging the error object instead adding the error as a string you get the correct stack trace.

**Before:** without the correct stacktrace

![bildschirmfoto 2018-07-04 um 20 54 53](https://user-images.githubusercontent.com/1698337/42291534-96bf5e56-7fcc-11e8-874f-60d395a0bb8d.png)

**After:** with correct stacktrace

![bildschirmfoto 2018-07-04 um 20 54 03](https://user-images.githubusercontent.com/1698337/42291538-98d9a408-7fcc-11e8-8ec2-6082b8e7d614.png)
