### PR TITLE
Added dot dot dot scss mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
  - FEATURE: Added truncate component. #32
+ - FEATURE: Added dot dot dot scss mixin. #31
 
 ## 1.4.1
 

--- a/scss/tools/_dot-dot-dot.scss
+++ b/scss/tools/_dot-dot-dot.scss
@@ -1,0 +1,5 @@
+@mixin dotDotDot() {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}


### PR DESCRIPTION
The dot dot dot mixin cuts a too long text and added the ellipsis:

```scss
.example {
    @include dotDotDot();
}
```

outputs:

```css
.example {
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
}
```