### PR TITLE
Add truncate component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ Thumbs.db
 # NPM
 /node_modules
 yarn-error.log
+yarn.lock
 
 !**/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## unreleased
+
+ - FEATURE: Added truncate component. #32
+
 ## 1.4.1
 
  - FEATURE: Added return of instance in startComponent. #30

--- a/scss/tools/_media.scss
+++ b/scss/tools/_media.scss
@@ -187,4 +187,3 @@ $media-breakpoints: $breakpoints !default;
         }
     }
 }
-

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -10,20 +10,20 @@ var $ = require('jquery');
  */
 function debounce(func, wait, immediate) {
     var timeout;
-    
+
     return function() {
         var context = this;
         var args = arguments;
-        
+
         clearTimeout(timeout);
         timeout = setTimeout(function() {
             timeout = null;
-            
+
             if (!immediate) {
                 func.apply(context, args);
             }
         }, wait);
-        
+
         if (immediate && !timeout) {
             func.apply(context, args);
         }

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -14,7 +14,7 @@ module.exports = function Truncate() {
      *    Lorem ipsum ...
      * </div>
      *
-     * import truncate from 'massive-web/src/truncate';
+     * import truncate from 'massive-web/src/components/truncate';
      * truncate.initialize($('#truncate'), {});
      *
      * @param {jQuery} $el

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -33,22 +33,12 @@ function debounce(func, wait, immediate) {
 module.exports = function Truncate() {
     var truncate = {};
 
-    truncate.separator = ' ...';
-    truncate.debounceDelay = 250;
-
     truncate.initialize = function initialize($el, options) {
         truncate.$el = $el;
 
-        if (options) {
-            if (options.separator) {
-                truncate.separator = options.separator;
-            }
-
-            if (options.debounceDelay) {
-                truncate.debounceDelay = options.debounceDelay;
-            }
-        }
-
+        truncate.separator = options.separator || ' ...';
+        truncate.debounceDelay = options.debounceDelay || 250;
+        
         truncate.text = truncate.$el.text().trim();
         truncate.$inner = $('<span></span>').text(truncate.text).css('display', 'block');
         truncate.$el.html(truncate.$inner).css('display', 'block');

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -3,32 +3,7 @@
 'use strict';
 
 var $ = require('jquery');
-
-// Extracted from UnderscoreJS
-/**
- * @ignore
- */
-function debounce(func, wait, immediate) {
-    var timeout;
-
-    return function() {
-        var context = this;
-        var args = arguments;
-
-        clearTimeout(timeout);
-        timeout = setTimeout(function() {
-            timeout = null;
-
-            if (!immediate) {
-                func.apply(context, args);
-            }
-        }, wait);
-
-        if (immediate && !timeout) {
-            func.apply(context, args);
-        }
-    };
-}
+var debounce = require('../services/debounce');
 
 module.exports = function Truncate() {
     var truncate = {};

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -61,7 +61,7 @@ module.exports = function Truncate() {
 
     truncate.calculateRegex = function calculateRegex() {
         var separatorRegex = truncate.separator.split('').map(c => '\\' + c).join('');
-        truncate.regex = new RegExp('\\W*\\s(?:\\S*|\\S*' + separatorRegex + ')$');
+        truncate.regex = new RegExp('\\W*\\s?(?:\\S*|\\S*' + separatorRegex + ')$');
     };
 
     truncate.calculateText = function calculateText() {
@@ -72,6 +72,10 @@ module.exports = function Truncate() {
 
         while (truncate.$inner.outerHeight() > height) {
             truncate.$inner.text(function(index, text) {
+                if (text === truncate.separator) {
+                  return '';
+                }
+
                 return text.replace(truncate.regex, truncate.separator);
             });
         }

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -73,7 +73,7 @@ module.exports = function Truncate() {
         while (truncate.$inner.outerHeight() > height) {
             truncate.$inner.text(function(index, text) {
                 if (text === truncate.separator) {
-                  return '';
+                    return '';
                 }
 
                 return text.replace(truncate.regex, truncate.separator);

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -8,9 +8,22 @@ var debounce = require('../services/debounce');
 module.exports = function Truncate() {
     var truncate = {};
 
+    /**
+     * @example
+     * <div id="truncate" style="overflow: hidden; line-height: 20px; max-height: 60px;">
+     *    Lorem ipsum ...
+     * </div>
+     *
+     * import truncate from 'massive-web/src/truncate';
+     * truncate.initialize($('#truncate'), {});
+     *
+     * @param {jQuery} $el
+     * @param {object} options
+     */
     truncate.initialize = function initialize($el, options) {
         truncate.$el = $el;
 
+        // Set default options if no custom options are defined
         truncate.separator = options.separator || ' ...';
         truncate.debounceDelay = options.debounceDelay || 250;
 
@@ -24,11 +37,17 @@ module.exports = function Truncate() {
         $(window).on('resize', debounce(truncate.calculateText, truncate.debounceDelay));
     };
 
+    /**
+     * Calculate regex based on the separator.
+     */
     truncate.calculateRegex = function calculateRegex() {
         var separatorRegex = truncate.separator.split('').map(c => '\\' + c).join('');
         truncate.regex = new RegExp('\\W*\\s?(?:\\S*|\\S*' + separatorRegex + ')$');
     };
 
+    /**
+     * Calculate output text based on the element's height.
+     */
     truncate.calculateText = function calculateText() {
         var height;
 

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -5,6 +5,9 @@
 var $ = require('jquery');
 
 // Extracted from UnderscoreJS
+/**
+ * @ignore
+ */
 function debounce(func, wait, immediate) {
     var timeout;
     return function() {
@@ -53,12 +56,12 @@ module.exports = function Truncate() {
     };
 
     truncate.calculateText = function calculateText() {
+        var height;
+
         truncate.$inner.text(truncate.text);
-        var height = truncate.$el.height();
-        console.log("Max Height", height);
+        height = truncate.$el.height();
 
         while (truncate.$inner.outerHeight() > height) {
-            console.log("Computed Height", truncate.$inner.outerHeight());
             truncate.$inner.text(function (index, text) {
                 return text.replace(truncate.regex, truncate.separator);
             });

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -10,14 +10,23 @@ var $ = require('jquery');
  */
 function debounce(func, wait, immediate) {
     var timeout;
+    
     return function() {
-        var context = this, args = arguments;
+        var context = this;
+        var args = arguments;
+        
         clearTimeout(timeout);
         timeout = setTimeout(function() {
             timeout = null;
-            if (!immediate) func.apply(context, args);
+            
+            if (!immediate) {
+                func.apply(context, args);
+            }
         }, wait);
-        if (immediate && !timeout) func.apply(context, args);
+        
+        if (immediate && !timeout) {
+            func.apply(context, args);
+        }
     };
 }
 
@@ -62,7 +71,7 @@ module.exports = function Truncate() {
         height = truncate.$el.height();
 
         while (truncate.$inner.outerHeight() > height) {
-            truncate.$inner.text(function (index, text) {
+            truncate.$inner.text(function(index, text) {
                 return text.replace(truncate.regex, truncate.separator);
             });
         }

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -1,0 +1,71 @@
+// Truncate text component module
+
+'use strict';
+
+var $ = require('jquery');
+
+// Extracted from UnderscoreJS
+function debounce(func, wait, immediate) {
+    var timeout;
+    return function() {
+        var context = this, args = arguments;
+        clearTimeout(timeout);
+        timeout = setTimeout(function() {
+            timeout = null;
+            if (!immediate) func.apply(context, args);
+        }, wait);
+        if (immediate && !timeout) func.apply(context, args);
+    };
+}
+
+module.exports = function Truncate() {
+    var truncate = {};
+
+    truncate.separator = ' ...';
+    truncate.debounceDelay = 250;
+
+    truncate.initialize = function initialize($el, options) {
+        truncate.$el = $el;
+
+        if (options) {
+            if (options.separator) {
+                truncate.separator = options.separator;
+            }
+
+            if (options.debounceDelay) {
+                truncate.debounceDelay = options.debounceDelay;
+            }
+        }
+
+        truncate.text = truncate.$el.text().trim();
+        truncate.$inner = $('<span></span>').text(truncate.text).css('display', 'block');
+        truncate.$el.html(truncate.$inner).css('display', 'block');
+
+        truncate.calculateRegex();
+        truncate.calculateText();
+
+        $(window).on('resize', debounce(truncate.calculateText, truncate.debounceDelay));
+    };
+
+    truncate.calculateRegex = function calculateRegex() {
+        var separatorRegex = truncate.separator.split('').map(c => '\\' + c).join('');
+        truncate.regex = new RegExp('\\W*\\s(?:\\S*|\\S*' + separatorRegex + ')$');
+    };
+
+    truncate.calculateText = function calculateText() {
+        truncate.$inner.text(truncate.text);
+        var height = truncate.$el.height();
+        console.log("Max Height", height);
+
+        while (truncate.$inner.outerHeight() > height) {
+            console.log("Computed Height", truncate.$inner.outerHeight());
+            truncate.$inner.text(function (index, text) {
+                return text.replace(truncate.regex, truncate.separator);
+            });
+        }
+    };
+
+    return {
+        initialize: truncate.initialize
+    };
+};

--- a/src/components/truncate.js
+++ b/src/components/truncate.js
@@ -38,7 +38,7 @@ module.exports = function Truncate() {
 
         truncate.separator = options.separator || ' ...';
         truncate.debounceDelay = options.debounceDelay || 250;
-        
+
         truncate.text = truncate.$el.text().trim();
         truncate.$inner = $('<span></span>').text(truncate.text).css('display', 'block');
         truncate.$el.html(truncate.$inner).css('display', 'block');

--- a/src/services/debounce.js
+++ b/src/services/debounce.js
@@ -1,0 +1,30 @@
+// Debounce function
+
+'use strict';
+
+/**
+ * Extracted from UnderscoreJS
+ *
+ * @ignore
+ */
+module.exports = function debounce(func, wait, immediate) {
+    var timeout;
+
+    return function() {
+        var context = this;
+        var args = arguments;
+
+        clearTimeout(timeout);
+        timeout = setTimeout(function() {
+            timeout = null;
+
+            if (!immediate) {
+                func.apply(context, args);
+            }
+        }, wait);
+
+        if (immediate && !timeout) {
+            func.apply(context, args);
+        }
+    };
+}

--- a/src/services/debounce.js
+++ b/src/services/debounce.js
@@ -27,4 +27,4 @@ module.exports = function debounce(func, wait, immediate) {
             func.apply(context, args);
         }
     };
-}
+};


### PR DESCRIPTION
Adds a component which truncates an element's text to the element's height.

Set `overflow: hidden` and e.g. `line-height: 20px` and `max-height: calc(20px * 3)` to the components element to truncate the text of that element to 3 lines.

This component also works with responsive breakpoints.

A custom separator can be defined in the options. e.g. `{ separator: '!!!' }`
A custom debounceDelay for the window resize function can also be set in the options. e.g. `{ debounceDelay: 500 }`