### PR TITLE
Remove jQuery as dependency of web core js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+ - ENHANCEMENT: Mark lazy.js implementation as experimental. #38
  - ENHANCEMENT: Remove jQuery as dependency of web core js. #38
  - ENHANCEMENT: Change api request to use json instead of html. #37
  - FEATURE: Add support for multiple arguments in service call. #36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+ - ENHANCEMENT: Remove jQuery as dependency of web core js. #38
  - ENHANCEMENT: Change api request to use json instead of html. #37
  - FEATURE: Add support for multiple arguments in service call. #36
  - ENHANCEMENT: Rename src folder to js. #35

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ A component can be created using different js patterns:
 
 ```js
 // js/components/test-revealing-pattern.js
+var $ = require('jquery');
 
 module.exports = (function() {
     var test = {};
 
-    test.initialize = function($el, options) {
+    test.initialize = function(el, options) {
         test.text = options.text;
-        $el.click(test.say.bind(this));
+        $(el).click(test.say.bind(this));
     };
 
     test.say = function() {
@@ -61,12 +62,13 @@ module.exports = (function() {
 
 ```js
 // js/components/test-prototype-pattern.js
+var $ = require('jquery');
 
 var test = function() {};
 
-test.prototype.initialize = function($el, options) {
+test.prototype.initialize = function(el, options) {
     this.text = options.text;
-    $el.click(this.say.bind(this));
+    $(el).click(this.say.bind(this));
 };
 
 test.prototype.say = function() {
@@ -80,15 +82,16 @@ module.exports = test;
 
 ```js
 // js/components/test-class.js
+import $ from 'jquery';
 
 export default class Test {
     constructor() {
         this.text = '';
     }
 
-    initialize($el, options) {
+    initialize(el, options) {
         this.text = options.text;
-        $el.click(this.say);
+        $(el).click(this.say);
     }
 
     say() {

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,40 @@
 # 2.0.0
 
+## jQuery removed from web component
+
+Web component initialize method will not longer get a jQuery Element
+instead it will get a basic javascript HTMLElement. This allows
+to use web-js without jQuery and detect which components really need
+jQuery as there dependency.
+
+**Before**
+
+```js
+initialize($el) {
+
+}
+
+// or
+
+initialize($el, options) {
+
+}
+```
+
+**After**
+
+```js
+initialize(el) {
+    var $el = el;
+}
+
+// or
+
+initialize($el, options) {
+    var $el = el;
+}
+```
+
 ## Api service dataType changed
 
 The api service will now use json dataType instead of html.

--- a/js/components/container-link.js
+++ b/js/components/container-link.js
@@ -1,15 +1,16 @@
 // Container link component.
-
 'use strict';
+
+var $ = require('jquery');
 
 module.exports = function ContainerLink() {
     var containerLink = {};
 
     /**
-     * @param {jQuery} $el
+     * @param {HTMLELement} el
      */
-    containerLink.initialize = function initialize($el) {
-        containerLink.$el = $el;
+    containerLink.initialize = function initialize(el) {
+        containerLink.$el = $(el);
 
         // Run init functions.
         containerLink.bindEvents();

--- a/js/components/expand.js
+++ b/js/components/expand.js
@@ -1,5 +1,4 @@
 // Expand trigger component module
-
 'use strict';
 
 var $ = require('jquery');
@@ -7,10 +6,14 @@ var $ = require('jquery');
 module.exports = function Expand() {
     var expand = {};
 
-    expand.initialize = function initialize($el, options) {
+    /**
+     * @param {HTMLELement} el
+     * @param {object} options
+     */
+    expand.initialize = function initialize(el, options) {
         // Define necessary component elements, instance $el handed in on initialization
-        expand.$el = $el;
-        expand.id = $el.attr('id');
+        expand.$el = $(el);
+        expand.id = expand.$el.attr('id');
         expand.closeOnEsc = options.closeOnEsc ? options.closeOnEsc : false;
         expand.$container = options.container ? $('#' + options.container) : $('#' + expand.id + '-container');
         expand.modifier = options.modifier ? options.modifier : '--open';
@@ -21,6 +24,9 @@ module.exports = function Expand() {
         expand.bindEvents();
     };
 
+    /**
+     * @param {jQuery} $element
+     */
     expand.getFirstClass = function getFirstClass($element) {
         return $element.attr('class').split(' ')[0];
     };

--- a/js/components/truncate.js
+++ b/js/components/truncate.js
@@ -17,11 +17,11 @@ module.exports = function Truncate() {
      * import truncate from 'massive-web/src/components/truncate';
      * truncate.initialize($('#truncate'), {});
      *
-     * @param {jQuery} $el
+     * @param {HTMLElement} el
      * @param {object} options
      */
-    truncate.initialize = function initialize($el, options) {
-        truncate.$el = $el;
+    truncate.initialize = function initialize(el, options) {
+        truncate.$el = $(el);
 
         // Set default options if no custom options are defined
         truncate.separator = options.separator || ' ...';

--- a/js/core.js
+++ b/js/core.js
@@ -1,8 +1,6 @@
-// Application Sandbox
+// Web component and service registry
 
 'use strict';
-
-var $ = require('jquery');
 
 /**
  * Web container for all components and services.
@@ -151,12 +149,12 @@ var web = (function web() {
     /**
      * Get the component dom element.
      * @param {String} id
-     * @return {jQuery|HTMLElement}
+     * @return {HTMLElement}
      * @method getElement
      * @private
      */
     web.getElement = function(id) {
-        return $('#' + id);
+        return document.getElementById(id);
     };
 
     /**
@@ -194,7 +192,7 @@ var web = (function web() {
 
             instance = function() {};
 
-            $.extend(instance.prototype, component);
+            Object.assign(instance.prototype, component);
 
             componentRegistry[name] = instance;
 

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -6,6 +6,8 @@ var $ = require('jquery');
 var web = require('./core');
 
 /**
+ * @experimental
+ *
  * Web container for all components and services.
  */
 var lazy = (function lazy() {


### PR DESCRIPTION
fixes #22 

Allows to use web-js without jQuery.