### PR TITLE
Add animated link scss mixin

### DIFF
--- a/scss/tools/_animation-link.scss
+++ b/scss/tools/_animation-link.scss
@@ -1,0 +1,25 @@
+$animatedLinkColor: currentColor !default;
+$animatedLinkSize: 2px !default;
+$animatedLinkSpeed: 0.25s !default;
+
+@mixin animatedLink($color: $animatedLinkColor, $size: $animatedLinkSize) {
+    &:hover,
+    &:focus {
+        animation-duration: $animatedLinkSpeed;
+        animation-name: linkHoverAnimation;
+        background-image: linear-gradient($color, $color);
+        background-position: left bottom;
+        background-repeat: no-repeat;
+        background-size: 100% $size;
+    }
+}
+
+@keyframes linkHoverAnimation {
+    0% {
+        background-size: 0 $animatedLinkSize;
+    }
+
+    100% {
+        background-size: 100% $animatedLinkSize;
+    }
+}


### PR DESCRIPTION
The animated link mixin adds a hover animation on a link which also works for multiline links.

Example: https://jsfiddle.net/aj6kgth0/