### PR TITLE
Fix menu button active state for chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
  
+ - BUGFIX: Fix menu button for chrome. #47
  - FEATURE: Add animation link hover scss mixin. #46
  - FEATURE: Add window scroll js component. #45
  - FEATURE: Add animated menu button mixin. #44

--- a/scss/tools/_menu-button.scss
+++ b/scss/tools/_menu-button.scss
@@ -41,10 +41,11 @@
         }
     }
 
-    &:hover,
     &:focus {
         outline: none;
+    }
 
+    &:hover {
         &::after {
             bottom: calc(50% - #{$halfLineSize});
             transform: rotate(0deg);


### PR DESCRIPTION
In chrome blink engine the focus does not lose its state after click. Which should by spec normally happen like in firefox, safari, ... Aslong as this issue exist the menu button can not provide a focus state without JS so the focus state was removed.