### PR TITLE
Add possibility to extend container link attributes

### DIFF
--- a/scss/tools/_container-link.scss
+++ b/scss/tools/_container-link.scss
@@ -6,5 +6,6 @@
         left: 0;
         top: 0;
         width: 100%;
+        @content;
     }
 }


### PR DESCRIPTION
If an the container link need another z-index it can be set as attributes:

```scss
.my-link {
    @include containerLink() {
        z-index: 11;
    }
}
```